### PR TITLE
feat: module difference

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -2,5 +2,6 @@
   "token": "",
   "clientId": "",
   "guildId": "",
-  "monitorChannel": ""
+  "monitorChannel": "",
+  "ignoreModules": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-pm2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/index.js",
   "author": "TurtIeSocks <58572875+TurtIeSocks@users.noreply.github.com>",
   "license": "MIT",


### PR DESCRIPTION
- add config option to ignore modules and only list processes
- indicate whether a process is a module in the embed